### PR TITLE
feat(yarn): add yarn js package manager

### DIFF
--- a/2.0.0/Dockerfile
+++ b/2.0.0/Dockerfile
@@ -6,6 +6,10 @@ MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
+# Update yarn source
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list
+
 # Update and install common dependencies
 RUN apt-get update && apt-get install -y \
     autoconf \
@@ -33,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     nodejs \
     zlib1g-dev \
+    yarn \
   && rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -6,6 +6,10 @@ MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
+# Update yarn source
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list
+
 # Update and install common dependencies
 RUN apt-get update && apt-get install -y \
     autoconf \
@@ -33,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     nodejs \
     zlib1g-dev \
+    yarn \
   && rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -6,6 +6,10 @@ MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
+# Update yarn source
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list
+
 # Update and install common dependencies
 RUN apt-get update && apt-get install -y \
     autoconf \
@@ -33,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     nodejs \
     zlib1g-dev \
+    yarn \
   && rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -6,6 +6,10 @@ MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
+# Update yarn source
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list
+
 # Update and install common dependencies
 RUN apt-get update && apt-get install -y \
     autoconf \
@@ -33,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     netcat \
     nodejs \
     zlib1g-dev \
+    yarn \
   && rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation


### PR DESCRIPTION
# Yarn as JS package manager

## Motivation

I think it would be an improvement to add `yarn` to these images because:
- it offers many advantages over `npm`
- it is increasingly being used as dependency for technologies in which Platanus depends (Rails 5.1, ...)
- it is not included with `nodejs` (unlike `npm`)
- it is required to run the `assets:precompile` task on Circle CI (see https://github.com/platanus/potassium/pull/135)