### PR TITLE
fix(dockerfile): install bundler 2 in version 2.5 and 2.6

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -2,6 +2,8 @@ FROM ruby:2.5
 
 MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 
+RUN gem install bundler --version '~> 2.0.2'
+
 # Update node source
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
   && rm -rf /var/lib/apt/lists/*

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:2.6
 MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 
+RUN gem install bundler --version '~> 2.0.2'
+
 # Update node source
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR installs bundler 2. This in addition with the version 1 installed by default give compatibility to both versions.
The change was applied only in versions 2.5 and 2.6, given that in platanus we are currently using 2.5.