### PR TITLE
fix(2.7): use latest LTS version for node (12)

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Juan Ignacio Donoso "juan.ignacio@platan.us"
 RUN gem install bundler --version '~> 2.0.2'
 
 # Update node source
-RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
 # Update yarn source


### PR DESCRIPTION
Node 13 is not an LTS version, we should use LTS versions for production and testing builds. Node 12 is, as stated [here in the LTS schedule](https://nodejs.org/en/about/releases/).